### PR TITLE
fix: eliminate image2stl  exception on linux by fixing import statement

### DIFF
--- a/stl_tools/image2stl.py
+++ b/stl_tools/image2stl.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 
 import numpy as np
-from numpy2stl import numpy2stl
+from stl_tools.numpy2stl import numpy2stl
 from pylab import imread
 from scipy.ndimage import gaussian_filter
 


### PR DESCRIPTION
Not sure if it's an OS dependent thing, but image2stl raises an exception on Linux because of the import statement for numpy2stl 

Fixes: https://github.com/thearn/stl_tools/issues/8 